### PR TITLE
Resolves GH-1: Fix formatting of header to match GitHub documentation

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- GH-1: Fixed malformed signature (security) header generated as part of webhook requests using a secret by the `push` command
 
 ## [0.1.0]
 ### Added

--- a/src/main/java/org/starchartlabs/lure/command/PushCommand.java
+++ b/src/main/java/org/starchartlabs/lure/command/PushCommand.java
@@ -72,7 +72,7 @@ public class PushCommand implements Runnable {
 
     @Nullable
     @Option(name = "-s", aliases = { "--secret" }, required = false,
-    usage = "Specifies the webhook secret to secure the event post with")
+            usage = "Specifies the webhook secret to secure the event post with")
     private String webhookSecret;
 
     @Option(name = "-c", aliases = { "--content" }, required = true,
@@ -129,7 +129,7 @@ public class PushCommand implements Runnable {
         if (webhookSecret != null) {
             HmacUtils hmacUtils = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, webhookSecret);
 
-            result = hmacUtils.hmacHex(payload);
+            result = "sha1=" + hmacUtils.hmacHex(payload);
         }
 
         return Optional.ofNullable(result);

--- a/src/test/java/org/starchartlabs/lure/test/PushCommandTest.java
+++ b/src/test/java/org/starchartlabs/lure/test/PushCommandTest.java
@@ -89,7 +89,7 @@ public class PushCommandTest {
     @Test
     public void pushWithSecret() throws Exception {
         TestLogger testLogger = TestLoggerFactory.getTestLogger(PushCommand.class);
-        String expectedSignature = "24510be1a28ed09a521e5929842ca47ebc05b414";
+        String expectedSignature = "sha1=24510be1a28ed09a521e5929842ca47ebc05b414";
 
         String eventName = "test-event";
         String contentPath = getClass().getClassLoader().getResource(BASIC_JSON_PAYLOAD.toString()).toURI()


### PR DESCRIPTION
Previously, the security header generated from a provided webhook secret
only consisted of the generated value. GitHub documents that when a
webhook is sent, they send `sha1=`, followed by the value. This
mis-match was causing mocked webhook requests using secrets to fail.

This change adds the required prefix when a secret is provided as part
of the generated value