### PR TITLE
Resolves GH-3: Adds postbin commmand for piping captured requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   
 notifications:
   email:

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added "postbin" command which allows piping payloads from Postb.in to a URL in the same manner as GitHub webhooks
 
 ## [0.1.1]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -37,11 +37,19 @@ Lure is be a command-line interface for sending webhooks payloads on a local sys
 The current in-development code base supports:
 
 - `push`: Pushes a provided payload to an indicated web URL, mimicing the GitHub webook call pattern
-  - `--target-url`: "Specifies the server URL to POST the event to. Required
-  - `--event-name`: "Specifies the GitHub event name to send as. Required
+  - `--target-url`: Specifies the server URL to POST the event to. Required
+  - `--event-name`: Specifies the GitHub event name to send as. Required
   - `--secret`: Specifies the webhook secret to secure the event post with
-  - `--content`: Specifies the file containing the event content to send. Require
+  - `--content`: Specifies the file containing the event content to send. Required
   
 Example: `java -jar lure-(version)-capsule.jar push --target-url http://localhost/webhook --secret totallySecure --event-name event --content ./content.json`
+
+- `postbin`: Pipes a payloads from postb.in to an indicated web URL, mimicing the GitHub webook call pattern
+  - `--target-url`: Specifies the server URL to POST the event to. Required
+  - `--bin-id`: Specifies the Postbin bin ID to poll. Required
+  - `--poll-frequency`: Specifies the frequency in seconds to poll Postbin for new requests at, must be greater than 0. Defaults to 10 seconds
+  - `--postbin-root-url`: Specifies the root URL of Postbin to use. Defaults to https://postb.in/api
+  
+Example: `java -jar lure-(version)-capsule.jar postbin --target-url http://localhost/webhook --bin-id abcdefg`
 
  

--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,11 @@ dependencies {
     compileOnly 'com.google.code.findbugs:jsr305'
     
     compile 'args4j:args4j'
+    compile 'com.google.code.gson:gson'
     compile 'com.squareup.okhttp3:okhttp'
     compile 'commons-codec:commons-codec'
     compile 'org.slf4j:slf4j-api'
+    compile 'org.starchartlabs.alloy:alloy-core'
     
     capsuleRuntime 'org.slf4j:slf4j-simple'
     

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -6,6 +6,8 @@ args4j:args4j=2.33
 
 com.google.code.findbugs:jsr305=3.0.2
 
+com.google.code.gson:gson=2.8.5
+
 com.squareup.okhttp3:mockwebserver=3.14.1
 com.squareup.okhttp3:okhttp=3.14.1
 
@@ -13,6 +15,8 @@ commons-codec:commons-codec=1.12
 
 org.slf4j:slf4j-api=1.7.26
 org.slf4j:slf4j-simple=1.7.26
+
+org.starchartlabs.alloy:alloy-core=0.4.1
 
 org.testng:testng=6.14.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Application Versions
-version=0.1.2-SNAPSHOT
+version=0.2.0-SNAPSHOT
 
 # Consumed Language/Build System Versions
 # TODO romeara - upgrading to 4.5.1 breaks the Jacoco report merge plug-in

--- a/src/main/java/org/starchartlabs/lure/CommandLineInterface.java
+++ b/src/main/java/org/starchartlabs/lure/CommandLineInterface.java
@@ -29,6 +29,7 @@ import org.kohsuke.args4j.spi.SubCommandHandler;
 import org.kohsuke.args4j.spi.SubCommands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.starchartlabs.lure.command.PostbinCommand;
 import org.starchartlabs.lure.command.PushCommand;
 
 /**
@@ -44,7 +45,8 @@ public class CommandLineInterface {
 
     @Argument(handler = SubCommandHandler.class)
     @SubCommands({
-        @SubCommand(name = PushCommand.COMMAND_NAME, impl = PushCommand.class)
+            @SubCommand(name = PushCommand.COMMAND_NAME, impl = PushCommand.class),
+            @SubCommand(name = PostbinCommand.COMMAND_NAME, impl = PostbinCommand.class),
     })
     private Runnable command;
 

--- a/src/main/java/org/starchartlabs/lure/command/PostbinCommand.java
+++ b/src/main/java/org/starchartlabs/lure/command/PostbinCommand.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.starchartlabs.lure.command;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.starchartlabs.lure.model.postbin.PostbinShiftResponse;
+import org.starchartlabs.lure.model.postbin.RecordedRequest;
+
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+/**
+ * Command line sub-command that will pull requests from PostBin and push it to a web URL following patterns defined for
+ * GitHub webhook calls
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class PostbinCommand implements Runnable {
+
+    public static final String COMMAND_NAME = "postbin";
+
+    private static final Set<String> PASSED_HEADERS = Stream
+            .of("X-GitHub-Event", "X-GitHub-Delivery", "X-Hub-Signature", "User-Agent")
+            .map(String::toLowerCase)
+            .collect(Collectors.toSet());
+
+    /** Logger reference to output information to the application log files */
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final OkHttpClient httpClient = new OkHttpClient();
+
+    @Option(name = "-t", aliases = { "--target-url" }, required = true,
+            usage = "Specifies the server URL to POST the event to. Required")
+    private String targetUrl;
+
+    @Option(name = "-b", aliases = { "--bin-id" }, required = true,
+            usage = "Specifies the Postbin bin ID to poll. Required")
+    private String binId;
+
+    @Option(name = "-p", aliases = { "--poll-frequency" }, required = false,
+            usage = "Specifies the frequency in seconds to poll Postbin for new requests at, must be greater than 0. Defaults to 10 seconds")
+    private int pollFrequencySeconds = 10;
+
+    @Option(name = "-r", aliases = { "--postbin-root-url" }, required = false,
+            usage = "Specifies the root URL of Postbin to use. Defaults to https://postb.in/api")
+    private String rootUrl = "https://postb.in/api";
+
+    @Override
+    public void run() {
+        logger.info("Polling PostBin requests");
+        long millisecondsWait = TimeUnit.MILLISECONDS.convert(pollFrequencySeconds, TimeUnit.SECONDS);
+        PostbinShiftResponse currentResponse = null;
+        String sourceUrl = getShiftRequestUrl(binId);
+
+        logger.info("Reading requests from {}", sourceUrl);
+
+        while (currentResponse == null || currentResponse.isBinExists()) {
+            currentResponse = getResponse(sourceUrl);
+
+            currentResponse.getRecordedRequest()
+            .filter(rr -> Objects.equals(rr.getMethod(), "POST"))
+            .ifPresent(request -> postRequest(targetUrl, request));
+
+            boolean postRequest = Objects.equals("POST",
+                    currentResponse.getRecordedRequest().map(RecordedRequest::getMethod).orElse("POST"));
+
+            if (!postRequest) {
+                logger.info("Ignoring request, GitHub webhooks are expected to always operate via POST operations");
+            }
+
+            try {
+                Thread.sleep(millisecondsWait);
+            } catch (InterruptedException e) {
+                logger.error("Postbin polling interrupted", e);
+                break;
+            }
+        }
+
+        logger.info("Polling complete, Bin is no longer active");
+    }
+
+    private String getShiftRequestUrl(String binId) {
+        Objects.requireNonNull(binId);
+
+        return HttpUrl.get(rootUrl).newBuilder()
+                .addPathSegment("bin")
+                .addPathSegment(binId)
+                .addPathSegments("req/shift")
+                .build()
+                .toString();
+    }
+
+    private PostbinShiftResponse getResponse(String url) {
+        Objects.requireNonNull(url);
+
+        Request request = new Request.Builder()
+                .get()
+                .header("Accept", "application/json")
+                .header("User-Agent", "StarChart-Labs/lure")
+                .url(url)
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            PostbinShiftResponse postbinResponse = PostbinShiftResponse.fromResponse(response);
+            if (postbinResponse.isBinExists()) {
+                logger.info("Polled Postbin - Request {}",
+                        (postbinResponse.getRecordedRequest().isPresent() ? "present" : "not present"));
+            }
+
+            return postbinResponse;
+        } catch (IOException e) {
+            throw new RuntimeException("Error requesting data from PostBin", e);
+        }
+    }
+
+    private void postRequest(String url, RecordedRequest request) {
+        Objects.requireNonNull(request);
+
+        String contentType = request.getHeaders().stream()
+                .filter(header -> Objects.equals(header.getKey(), "Content-Type"))
+                .map(Entry::getValue)
+                .findAny()
+                .orElse("application/json");
+
+        Request.Builder requestBuilder = new Request.Builder()
+                .post(RequestBody.create(MediaType.get(contentType), request.getBody()))
+                .url(url);
+
+        // Only pass on GitHub headers to avoid posting errors from "host" and other such values
+        request.getHeaders().stream()
+        .filter(header -> !Objects.equals(header.getKey(), "Content-Type"))
+        .filter(header -> PASSED_HEADERS.contains(header.getKey().toLowerCase()))
+        .forEach(header -> requestBuilder.addHeader(header.getKey(), header.getValue()));
+
+        try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
+            if (response.isSuccessful()) {
+                logger.info("Successful POST of event to {} (HTTP: {}: {})", url, response.code(), response.message());
+            } else {
+                throw new RuntimeException(
+                        "Request to " + targetUrl + " unsuccessful (" + response.code() + " - " + response.message()
+                        + ")");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error executing request to " + targetUrl, e);
+        }
+    }
+
+}

--- a/src/main/java/org/starchartlabs/lure/command/PushCommand.java
+++ b/src/main/java/org/starchartlabs/lure/command/PushCommand.java
@@ -43,6 +43,7 @@ import okhttp3.Response;
  * Command line sub-command that will push raw data to a web URL following patterns defined for GitHub webhook calls
  *
  * @author romeara
+ * @since 0.1.0
  */
 public class PushCommand implements Runnable {
 
@@ -72,7 +73,7 @@ public class PushCommand implements Runnable {
 
     @Nullable
     @Option(name = "-s", aliases = { "--secret" }, required = false,
-            usage = "Specifies the webhook secret to secure the event post with")
+    usage = "Specifies the webhook secret to secure the event post with")
     private String webhookSecret;
 
     @Option(name = "-c", aliases = { "--content" }, required = true,

--- a/src/main/java/org/starchartlabs/lure/model/postbin/PostbinShiftResponse.java
+++ b/src/main/java/org/starchartlabs/lure/model/postbin/PostbinShiftResponse.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.starchartlabs.lure.model.postbin;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+import org.starchartlabs.alloy.core.Strings;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * Represents a response from the <a href="https://postb.in/api/#shift-req">postb.in "shift" API</a>
+ *
+ * <p>
+ * Represents a present request, a lack of available recorded request, and the possibility of the BIN no longer existing
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class PostbinShiftResponse {
+
+    private static final Gson GSON = new GsonBuilder().create();
+
+    private static final String BIN_DOESNT_EXIST_MESSAGE = "Bin Does Not Exist";
+
+    private final Optional<RecordedRequest> recordedRequest;
+
+    private final boolean binExists;
+
+    /**
+     * @param recordedRequest
+     *            The retrieved request, if available. Null if no request is present, or the bin doesn't exist
+     * @param binExists
+     *            True if the bin referenced is still active, false otherwise
+     */
+    private PostbinShiftResponse(@Nullable RecordedRequest recordedRequest, boolean binExists) {
+        this.recordedRequest = Optional.ofNullable(recordedRequest);
+        this.binExists = binExists;
+    }
+
+    /**
+     * @return The retrieved request, if available. Empty if no request is present, or the bin doesn't exist
+     * @since 0.2.0
+     */
+    public Optional<RecordedRequest> getRecordedRequest() {
+        return recordedRequest;
+    }
+
+    /**
+     * @return True if the bin referenced is still active, false otherwise
+     * @since 0.2.0
+     */
+    public boolean isBinExists() {
+        return binExists;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRecordedRequest(),
+                isBinExists());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PostbinShiftResponse) {
+            PostbinShiftResponse compare = (PostbinShiftResponse) obj;
+
+            result = Objects.equals(compare.getRecordedRequest(), getRecordedRequest())
+                    && Objects.equals(compare.isBinExists(), isBinExists());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("recordedRequest", getRecordedRequest())
+                .add("binExists", isBinExists())
+                .toString();
+    }
+
+    /**
+     * Parses an OkHttp {@link Response}, determining if the postb.in "Bin" called is still active, and if so if there
+     * was a request available to read
+     *
+     * @param response
+     *            The OkHttp response to process
+     * @return A representation of the state of the called "Bin" and any recorded request it contained
+     * @since 0.2.0
+     */
+    public static PostbinShiftResponse fromResponse(Response response) {
+        Objects.requireNonNull(response);
+
+        PostbinShiftResponse result = null;
+
+        if (response.code() == 200) {
+            try (ResponseBody body = response.body()) {
+                RecordedRequest recordedRequest = RecordedRequest.fromJson(body.string());
+
+                result = new PostbinShiftResponse(recordedRequest, true);
+            } catch (IOException e) {
+                throw new RuntimeException("Error reading recorded response from PostBin", e);
+            }
+        } else if (response.code() == 404) {
+            try (ResponseBody body = response.body()) {
+                ErrorResponse error = GSON.fromJson(body.string(), ErrorResponse.class);
+
+                if (Objects.equals(BIN_DOESNT_EXIST_MESSAGE, error.getMsg())) {
+                    result = new PostbinShiftResponse(null, false);
+                } else {
+                    result = new PostbinShiftResponse(null, true);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Error reading error response from PostBin", e);
+            }
+        } else {
+            throw new RuntimeException(Strings.format("Error reading recorded requests from PostBin (%s: %s)",
+                    response.code(), response.message()));
+        }
+
+        return result;
+    }
+
+    /**
+     * Represents response contents when an error occurred
+     *
+     * @author romeara
+     */
+    private static final class ErrorResponse {
+
+        @SerializedName("msg")
+        private final String msg;
+
+        // Suppressed as this is invoked by the JSON deserializer
+        @SuppressWarnings("unused")
+        public ErrorResponse(String msg) {
+            this.msg = msg;
+        }
+
+        public String getMsg() {
+            return msg;
+        }
+
+    }
+
+}

--- a/src/main/java/org/starchartlabs/lure/model/postbin/RecordedRequest.java
+++ b/src/main/java/org/starchartlabs/lure/model/postbin/RecordedRequest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.starchartlabs.lure.model.postbin;
+
+import java.lang.reflect.Type;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Represents a response describing a request captured by postb.in
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class RecordedRequest {
+
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapter(RecordedRequest.class, new Deserializer())
+            .create();
+
+    private final String method;
+
+    private final List<Entry<String, String>> headers;
+
+    private final String body;
+
+    /**
+     * @param method
+     *            The HTTP method used to make the request
+     * @param headers
+     *            Representation of the headers recorded with the request
+     * @param body
+     *            The JSON body of the recorded request
+     * @since 0.2.0
+     */
+    public RecordedRequest(String method, List<Entry<String, String>> headers, String body) {
+        this.method = Objects.requireNonNull(method);
+        this.headers = Objects.requireNonNull(headers);
+        this.body = Objects.requireNonNull(body);
+    }
+
+    /**
+     * @return The HTTP method used to make the request
+     * @since 0.2.0
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * @return Representation of the headers recorded with the request
+     * @since 0.2.0
+     */
+    public List<Entry<String, String>> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * @return The JSON body of the recorded request
+     * @since 0.2.0
+     */
+    public String getBody() {
+        return body;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getMethod(),
+                getHeaders(),
+                getBody());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof RecordedRequest) {
+            RecordedRequest compare = (RecordedRequest) obj;
+
+            result = Objects.equals(compare.getMethod(), getMethod())
+                    && Objects.equals(compare.getHeaders(), getHeaders())
+                    && Objects.equals(compare.getBody(), getBody());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("method", getMethod())
+                .add("headers", getHeaders())
+                .add("body", getBody())
+                .toString();
+    }
+
+    /**
+     * Deserializes a Java representation of a request recorded by postb.in
+     *
+     * @param json
+     *            JSON representation to parse/deserialize
+     * @return Java representation of the provided JSON
+     * @since 0.2.0
+     */
+    public static RecordedRequest fromJson(String json) {
+        Objects.requireNonNull(json);
+
+        return GSON.fromJson(json, RecordedRequest.class);
+    }
+
+    /**
+     * Handles custom JSON deserialization for request data via GSON deserialization
+     *
+     * @author romeara
+     */
+    private static final class Deserializer implements JsonDeserializer<RecordedRequest> {
+
+        private static final Gson GSON = new GsonBuilder()
+                .create();
+
+        @Override
+        public RecordedRequest deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            JsonObject responseObject = json.getAsJsonObject();
+
+            String method = responseObject.get("method").getAsString();
+
+            List<Entry<String, String>> headers = responseObject.get("headers").getAsJsonObject().entrySet().stream()
+                    .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().getAsString()))
+                    .collect(Collectors.toList());
+
+            String body = GSON.toJson(responseObject.get("body"));
+
+            return new RecordedRequest(method, headers, body);
+        }
+
+    }
+
+}

--- a/src/main/java/org/starchartlabs/lure/model/postbin/package-info.java
+++ b/src/main/java/org/starchartlabs/lure/model/postbin/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains classes which represent payloads sent to or received from postbin
+ *
+ * @author romeara
+ */
+package org.starchartlabs.lure.model.postbin;

--- a/src/test/java/org/starchartlabs/lure/test/PostbinCommandTest.java
+++ b/src/test/java/org/starchartlabs/lure/test/PostbinCommandTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.starchartlabs.lure.test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.starchartlabs.lure.CommandLineInterface;
+import org.starchartlabs.lure.command.PostbinCommand;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import uk.org.lidalia.slf4jext.Level;
+import uk.org.lidalia.slf4jtest.LoggingEvent;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+
+public class PostbinCommandTest {
+
+    private static final Path TEST_PAYLOADS_DIRECTORY = Paths.get("org", "starchartlabs", "lure", "test", "payloads",
+            "postbin");
+
+    private static final Path GET_PAYLOAD = TEST_PAYLOADS_DIRECTORY.resolve("recordedRequest.json");
+
+    private static final Path POST_PAYLOAD = TEST_PAYLOADS_DIRECTORY.resolve("recordedPostRequest.json");
+
+    private static final Path NO_REQUEST_PAYLOAD = TEST_PAYLOADS_DIRECTORY.resolve("notFoundNoRequest.json");
+
+    private static final Path BIN_EXPIRED_PAYLOAD = TEST_PAYLOADS_DIRECTORY.resolve("notFoundBinDoesntExist.json");
+
+    @Test
+    public void postbinFilteredByGet() throws Exception {
+        TestLogger testLogger = TestLoggerFactory.getTestLogger(PostbinCommand.class);
+
+        MockResponse response = new MockResponse()
+                .setBody(getContent(GET_PAYLOAD))
+                .setResponseCode(200);
+        MockResponse responseBinComplete = new MockResponse()
+                .setBody(getContent(BIN_EXPIRED_PAYLOAD))
+                .setResponseCode(404);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.enqueue(responseBinComplete);
+            server.start();
+
+            HttpUrl rootUrl = server.url("/api");
+            String binId = "binId";
+            String url = server.url("/webhook").toString();
+
+            String[] args = new String[] { PostbinCommand.COMMAND_NAME, "--target-url=" + url, "--bin-id=" + binId,
+                    "--postbin-root-url=" + rootUrl.toString(), "--poll-frequency=1" };
+
+            try {
+                CommandLineInterface.main(args);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 2);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getMethod(), "GET");
+                Assert.assertEquals(request.getHeader("Accept"), "application/json");
+                Assert.assertEquals(request.getHeader("User-Agent"), "StarChart-Labs/lure");
+                Assert.assertEquals(request.getPath(), "/api/bin/" + binId + "/req/shift");
+
+                request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getMethod(), "GET");
+                Assert.assertEquals(request.getHeader("Accept"), "application/json");
+                Assert.assertEquals(request.getHeader("User-Agent"), "StarChart-Labs/lure");
+                Assert.assertEquals(request.getPath(), "/api/bin/" + binId + "/req/shift");
+
+                List<String> events = testLogger.getLoggingEvents().stream()
+                        .filter(event -> Level.INFO.equals(event.getLevel()))
+                        .map(LoggingEvent::getMessage)
+                        .collect(Collectors.toList());
+
+                Assert.assertTrue(
+                        events.contains(
+                                "Ignoring request, GitHub webhooks are expected to always operate via POST operations"),
+                        "Found: " + events);
+            }
+        }
+    }
+
+    @Test
+    public void postbin() throws Exception {
+        TestLogger testLogger = TestLoggerFactory.getTestLogger(PostbinCommand.class);
+
+        MockResponse response = new MockResponse()
+                .setBody(getContent(POST_PAYLOAD))
+                .setResponseCode(200);
+        MockResponse postResponse = new MockResponse()
+                .setResponseCode(200);
+        MockResponse responseBinComplete = new MockResponse()
+                .setBody(getContent(BIN_EXPIRED_PAYLOAD))
+                .setResponseCode(404);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.enqueue(postResponse);
+            server.enqueue(responseBinComplete);
+            server.start();
+
+            HttpUrl rootUrl = server.url("/api");
+            String binId = "binId";
+            String url = server.url("/webhook").toString();
+
+            String[] args = new String[] { PostbinCommand.COMMAND_NAME, "--target-url=" + url, "--bin-id=" + binId,
+                    "--postbin-root-url=" + rootUrl.toString(), "--poll-frequency=1" };
+
+            try {
+                CommandLineInterface.main(args);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 3);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getMethod(), "GET");
+                Assert.assertEquals(request.getHeader("Accept"), "application/json");
+                Assert.assertEquals(request.getHeader("User-Agent"), "StarChart-Labs/lure");
+                Assert.assertEquals(request.getPath(), "/api/bin/" + binId + "/req/shift");
+
+                request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getMethod(), "POST");
+                Assert.assertEquals(request.getHeader("Content-Type"), "application/json; charset=utf-8");
+                Assert.assertEquals(request.getHeader("User-Agent"), "curl/7.35.0");
+                Assert.assertEquals(request.getPath(), "/webhook");
+                Assert.assertEquals(request.getBody().readUtf8(), "{\"name\":\"value\"}");
+
+                request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getMethod(), "GET");
+                Assert.assertEquals(request.getHeader("Accept"), "application/json");
+                Assert.assertEquals(request.getHeader("User-Agent"), "StarChart-Labs/lure");
+                Assert.assertEquals(request.getPath(), "/api/bin/" + binId + "/req/shift");
+
+                List<String> events = testLogger.getLoggingEvents().stream()
+                        .filter(event -> Level.INFO.equals(event.getLevel()))
+                        .map(LoggingEvent::getMessage)
+                        .collect(Collectors.toList());
+
+                Assert.assertTrue(events.contains("Successful POST of event to {} (HTTP: {}: {})"),
+                        "Found: " + events);
+            }
+        }
+    }
+
+    @Test
+    public void postbinNoRequest() throws Exception {
+        MockResponse response = new MockResponse()
+                .setBody(getContent(NO_REQUEST_PAYLOAD))
+                .setResponseCode(404);
+        MockResponse responseBinComplete = new MockResponse()
+                .setBody(getContent(BIN_EXPIRED_PAYLOAD))
+                .setResponseCode(404);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.enqueue(responseBinComplete);
+            server.start();
+
+            HttpUrl rootUrl = server.url("/api");
+            String binId = "binId";
+            String url = server.url("/webhook").toString();
+
+            String[] args = new String[] { PostbinCommand.COMMAND_NAME, "--target-url=" + url, "--bin-id=" + binId,
+                    "--postbin-root-url=" + rootUrl.toString(), "--poll-frequency=1" };
+
+            try {
+                CommandLineInterface.main(args);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 2);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getMethod(), "GET");
+                Assert.assertEquals(request.getHeader("Accept"), "application/json");
+                Assert.assertEquals(request.getHeader("User-Agent"), "StarChart-Labs/lure");
+                Assert.assertEquals(request.getPath(), "/api/bin/" + binId + "/req/shift");
+
+                request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getMethod(), "GET");
+                Assert.assertEquals(request.getHeader("Accept"), "application/json");
+                Assert.assertEquals(request.getHeader("User-Agent"), "StarChart-Labs/lure");
+                Assert.assertEquals(request.getPath(), "/api/bin/" + binId + "/req/shift");
+            }
+        }
+    }
+
+    private String getContent(Path filePath) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                getClass().getClassLoader().getResourceAsStream(filePath.toString()), StandardCharsets.UTF_8))) {
+            return reader.lines()
+                    .collect(Collectors.joining("\n"));
+        }
+    }
+
+}

--- a/src/test/java/org/starchartlabs/lure/test/PushCommandTest.java
+++ b/src/test/java/org/starchartlabs/lure/test/PushCommandTest.java
@@ -36,8 +36,6 @@ import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 public class PushCommandTest {
 
-    private static final String COMMAND = "push";
-
     private static final Path TEST_PAYLOADS_DIRECTORY = Paths.get("org/starchartlabs/lure/test/payloads");
 
     private static final Path BASIC_JSON_PAYLOAD = TEST_PAYLOADS_DIRECTORY.resolve("basicJson.json");
@@ -59,7 +57,7 @@ public class PushCommandTest {
 
             String url = server.url("/webhook").toString();
 
-            String[] args = new String[] { COMMAND, "--target-url=" + url, "--event-name=" + eventName,
+            String[] args = new String[] { PushCommand.COMMAND_NAME, "--target-url=" + url, "--event-name=" + eventName,
                     "--content=" + contentPath };
 
             try {
@@ -104,7 +102,7 @@ public class PushCommandTest {
 
             String url = server.url("/webhook").toString();
 
-            String[] args = new String[] { COMMAND, "--target-url=" + url, "--event-name=" + eventName,
+            String[] args = new String[] { PushCommand.COMMAND_NAME, "--target-url=" + url, "--event-name=" + eventName,
                     "--secret=12345", "--content=" + contentPath };
 
             try {

--- a/src/test/java/org/starchartlabs/lure/test/model/postbin/PostbinShiftResponseTest.java
+++ b/src/test/java/org/starchartlabs/lure/test/model/postbin/PostbinShiftResponseTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.starchartlabs.lure.test.model.postbin;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.starchartlabs.lure.model.postbin.PostbinShiftResponse;
+import org.starchartlabs.lure.model.postbin.RecordedRequest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+public class PostbinShiftResponseTest {
+
+    private static final Path TEST_PAYLOAD_DIRECTORY = Paths.get("org", "starchartlabs", "lure", "test", "payloads",
+            "postbin");
+
+    private final OkHttpClient httpClient = new OkHttpClient();
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void fromResponse500() throws Exception {
+        MockResponse response = new MockResponse()
+                .setResponseCode(500);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            HttpUrl url = server.url("/shift");
+
+            Request request = new Request.Builder()
+                    .get()
+                    .header("Accept", "application/json")
+                    .url(url)
+                    .build();
+
+            try (Response res = httpClient.newCall(request).execute()) {
+                PostbinShiftResponse.fromResponse(res);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+            }
+        }
+    }
+
+
+    @Test
+    public void fromResponse404BinDoesntExist() throws Exception {
+        String payload = null;
+
+        try (BufferedReader reader = getClasspathReader(
+                TEST_PAYLOAD_DIRECTORY.resolve("notFoundBinDoesntExist.json"))) {
+            payload = reader.lines()
+                    .collect(Collectors.joining("\n"));
+        }
+
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(payload)
+                .setResponseCode(404);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            HttpUrl url = server.url("/shift");
+
+            Request request = new Request.Builder()
+                    .get()
+                    .header("Accept", "application/json")
+                    .url(url)
+                    .build();
+
+            try (Response res = httpClient.newCall(request).execute()) {
+                PostbinShiftResponse result = PostbinShiftResponse.fromResponse(res);
+
+                Assert.assertNotNull(result);
+                Assert.assertFalse(result.getRecordedRequest().isPresent());
+                Assert.assertFalse(result.isBinExists());
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+            }
+        }
+    }
+
+    @Test
+    public void fromResponse404NoRequest() throws Exception {
+        String payload = null;
+
+        try (BufferedReader reader = getClasspathReader(
+                TEST_PAYLOAD_DIRECTORY.resolve("notFoundNoRequest.json"))) {
+            payload = reader.lines()
+                    .collect(Collectors.joining("\n"));
+        }
+
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(payload)
+                .setResponseCode(404);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            HttpUrl url = server.url("/shift");
+
+            Request request = new Request.Builder()
+                    .get()
+                    .header("Accept", "application/json")
+                    .url(url)
+                    .build();
+
+            try (Response res = httpClient.newCall(request).execute()) {
+                PostbinShiftResponse result = PostbinShiftResponse.fromResponse(res);
+
+                Assert.assertNotNull(result);
+                Assert.assertFalse(result.getRecordedRequest().isPresent());
+                Assert.assertTrue(result.isBinExists());
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+            }
+        }
+    }
+
+    @Test
+    public void fromResponse200() throws Exception {
+        String expectedMethod = "GET";
+
+        List<Entry<String, String>> expectedHeaders = new ArrayList<>();
+        expectedHeaders.add(new AbstractMap.SimpleEntry<>("user-agent", "curl/7.35.0"));
+        expectedHeaders.add(new AbstractMap.SimpleEntry<>("host", "postb.in"));
+        expectedHeaders.add(new AbstractMap.SimpleEntry<>("accept", "*/*"));
+
+        String expectedBody = "{\"name\":\"value\"}";
+
+        RecordedRequest expectedRequest = new RecordedRequest(expectedMethod, expectedHeaders, expectedBody);
+        String payload = null;
+
+        try (BufferedReader reader = getClasspathReader(
+                TEST_PAYLOAD_DIRECTORY.resolve("recordedRequest.json"))) {
+            payload = reader.lines()
+                    .collect(Collectors.joining("\n"));
+        }
+
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(payload)
+                .setResponseCode(200);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            HttpUrl url = server.url("/shift");
+
+            Request request = new Request.Builder()
+                    .get()
+                    .header("Accept", "application/json")
+                    .url(url)
+                    .build();
+
+            try (Response res = httpClient.newCall(request).execute()) {
+                PostbinShiftResponse result = PostbinShiftResponse.fromResponse(res);
+
+                Assert.assertNotNull(result);
+                Assert.assertTrue(result.getRecordedRequest().isPresent());
+                Assert.assertEquals(result.getRecordedRequest().get(), expectedRequest);
+                Assert.assertTrue(result.isBinExists());
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+            }
+        }
+    }
+
+    private BufferedReader getClasspathReader(Path filePath) {
+        return new BufferedReader(
+                new InputStreamReader(getClass().getClassLoader().getResourceAsStream(filePath.toString()),
+                        StandardCharsets.UTF_8));
+    }
+
+}

--- a/src/test/java/org/starchartlabs/lure/test/model/postbin/RecordedRequestTest.java
+++ b/src/test/java/org/starchartlabs/lure/test/model/postbin/RecordedRequestTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.starchartlabs.lure.test.model.postbin;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.starchartlabs.lure.model.postbin.RecordedRequest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class RecordedRequestTest {
+
+    private static final List<Entry<String, String>> HEADERS = Collections
+            .singletonList(new AbstractMap.SimpleEntry<>("key", "value"));
+
+    private static final Path TEST_PAYLOAD = Paths.get("org", "starchartlabs", "lure", "test", "payloads",
+            "postbin", "recordedRequest.json");
+
+    private String recordedResponsePayload;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        try (BufferedReader reader = getClasspathReader(TEST_PAYLOAD)) {
+            recordedResponsePayload = reader.lines()
+                    .collect(Collectors.joining("\n"));
+        }
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void fromJsonNullJson() throws Exception {
+        RecordedRequest.fromJson(null);
+    }
+
+    @Test
+    public void fromJson() throws Exception {
+        String expectedMethod = "GET";
+
+        List<Entry<String, String>> expectedHeaders = new ArrayList<>();
+        expectedHeaders.add(new AbstractMap.SimpleEntry<>("user-agent", "curl/7.35.0"));
+        expectedHeaders.add(new AbstractMap.SimpleEntry<>("host", "postb.in"));
+        expectedHeaders.add(new AbstractMap.SimpleEntry<>("accept", "*/*"));
+
+        String expectedBody = "{\"name\":\"value\"}";
+
+        RecordedRequest result = RecordedRequest.fromJson(recordedResponsePayload);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getMethod(), expectedMethod);
+        Assert.assertEquals(result.getHeaders().size(), expectedHeaders.size());
+        Assert.assertTrue(result.getHeaders().containsAll(expectedHeaders));
+        Assert.assertEquals(result.getBody(), expectedBody);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullMethod() throws Exception {
+        new RecordedRequest(null, HEADERS, "body");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullHeaders() throws Exception {
+        new RecordedRequest("method", null, "body");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullBody() throws Exception {
+        new RecordedRequest("method", HEADERS, null);
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        RecordedRequest result = new RecordedRequest("method", HEADERS, "body");
+
+        Assert.assertEquals(result.getMethod(), "method");
+        Assert.assertEquals(result.getHeaders(), HEADERS);
+        Assert.assertEquals(result.getBody(), "body");
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        RecordedRequest result1 = new RecordedRequest("method", HEADERS, "body");
+        RecordedRequest result2 = new RecordedRequest("method", HEADERS, "body");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        RecordedRequest result = new RecordedRequest("method", HEADERS, "body");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    @Test
+    public void equalsDifferentClass() throws Exception {
+        RecordedRequest result = new RecordedRequest("method", HEADERS, "body");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        RecordedRequest result = new RecordedRequest("method", HEADERS, "body");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        RecordedRequest result1 = new RecordedRequest("method", HEADERS, "body1");
+        RecordedRequest result2 = new RecordedRequest("method", HEADERS, "body2");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        RecordedRequest result1 = new RecordedRequest("method", HEADERS, "body");
+        RecordedRequest result2 = new RecordedRequest("method", HEADERS, "body");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        RecordedRequest obj = new RecordedRequest("method", HEADERS, "body");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("method=method"));
+        Assert.assertTrue(result.contains("headers=" + HEADERS.toString()));
+        Assert.assertTrue(result.contains("body=body"));
+    }
+
+    private BufferedReader getClasspathReader(Path filePath) {
+        return new BufferedReader(
+                new InputStreamReader(getClass().getClassLoader().getResourceAsStream(filePath.toString()),
+                        StandardCharsets.UTF_8));
+    }
+
+}

--- a/src/test/resources/org/starchartlabs/lure/test/payloads/postbin/notFoundBinDoesntExist.json
+++ b/src/test/resources/org/starchartlabs/lure/test/payloads/postbin/notFoundBinDoesntExist.json
@@ -1,0 +1,1 @@
+{ "msg" : "Bin Does Not Exist" }

--- a/src/test/resources/org/starchartlabs/lure/test/payloads/postbin/notFoundNoRequest.json
+++ b/src/test/resources/org/starchartlabs/lure/test/payloads/postbin/notFoundNoRequest.json
@@ -1,0 +1,1 @@
+{ "msg" : "Request Does Not Exist" }

--- a/src/test/resources/org/starchartlabs/lure/test/payloads/postbin/recordedPostRequest.json
+++ b/src/test/resources/org/starchartlabs/lure/test/payloads/postbin/recordedPostRequest.json
@@ -1,0 +1,9 @@
+{
+  "method":"POST",
+  "path":"/BTigEN3y",
+  "headers":{"user-agent":"curl/7.35.0","host":"postb.in","accept":"*/*"},
+  "query":{},
+  "body":{ "name": "value" },
+  "ip":"1.2.3.4",
+  "inserted":1439468475026
+}

--- a/src/test/resources/org/starchartlabs/lure/test/payloads/postbin/recordedRequest.json
+++ b/src/test/resources/org/starchartlabs/lure/test/payloads/postbin/recordedRequest.json
@@ -1,0 +1,9 @@
+{
+  "method":"GET",
+  "path":"/BTigEN3y",
+  "headers":{"user-agent":"curl/7.35.0","host":"postb.in","accept":"*/*"},
+  "query":{},
+  "body":{ "name": "value" },
+  "ip":"1.2.3.4",
+  "inserted":1439468475026
+}


### PR DESCRIPTION
Adds a `postbin` command, which reads requests captured on the
"postb.in" web request website and forwards POSTs to the indicated URL