### PR TITLE
Force root project name for consistent builds

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'lure'


### PR DESCRIPTION
Prevent the checkout directory name of the repository from affecting the root project name variable by explicitly specifying it in settings